### PR TITLE
Removes the edge tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine
 
 RUN apk add --update bash jq
 RUN wget https://github.com/pivotal-cf/om/releases/download/0.26.0/om-linux -O /usr/local/bin/om && chmod +x /usr/local/bin/om


### PR DESCRIPTION
It seems `docker:edge` is failing to pull `om` due to TLS issues with `wget`.